### PR TITLE
issue #28  Update WayPoint.java

### DIFF
--- a/jpx/src/main/java/io/jenetics/jpx/WayPoint.java
+++ b/jpx/src/main/java/io/jenetics/jpx/WayPoint.java
@@ -456,7 +456,7 @@ public final class WayPoint implements Point, Serializable {
 	public String toString() {
 		return format(
 			"[lat=%s, lon=%s, ele=%s]",
-			_latitude, _latitude, _elevation
+			_latitude, _longitude, _elevation
 		);
 	}
 


### PR DESCRIPTION
Fixed typo in toString method. (printed _latitude twice before, instead of _latitude & _longitude ...)

