### PR TITLE
#49: Fix exception type thrown for invalid GPX files.

### DIFF
--- a/jpx/src/main/java/io/jenetics/jpx/WayPoint.java
+++ b/jpx/src/main/java/io/jenetics/jpx/WayPoint.java
@@ -446,10 +446,11 @@ public final class WayPoint implements Point, Serializable {
 
 	@Override
 	public String toString() {
-		return format(
-			"[lat=%s, lon=%s, ele=%s]",
-			_latitude, _longitude, _elevation
-		);
+		return _elevation != null
+			? format("[lat=%s, lon=%s, ele=%s]",
+				_latitude, _longitude, _elevation)
+			: format("[lat=%s, lon=%s]",
+				_latitude, _longitude);
 	}
 
 

--- a/jpx/src/test/java/io/jenetics/jpx/GPXTest.java
+++ b/jpx/src/test/java/io/jenetics/jpx/GPXTest.java
@@ -36,10 +36,12 @@ import java.io.ObjectOutputStream;
 import java.io.OutputStream;
 import java.nio.file.Paths;
 import java.util.Collections;
+import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.Optional;
 import java.util.Random;
 import java.util.function.Supplier;
+import java.util.stream.Collectors;
 
 import javax.xml.stream.XMLStreamException;
 
@@ -393,6 +395,44 @@ public class GPXTest extends XMLStreamTestBase<GPX> {
 		return new Object[][] {
 			{"/io/jenetics/jpx/ISSUE-38.gpx.xml"}
 		};
+	}
+
+	@Test(timeOut = 2000)
+	public void issue49_NPEForInvalidGPX() throws IOException {
+		final String resource = "/io/jenetics/jpx/ISSUE-49.gpx";
+
+		try (InputStream in = getClass().getResourceAsStream(resource)) {
+			GPX.read(in);
+			Assert.assertFalse(true, "GXP.read must throw.");
+		} catch (IOException e) {
+			Assert.assertEquals(e.getCause().getClass(), XMLStreamException.class);
+			Assert.assertTrue(e.getMessage().contains("Unexpected element"));
+		}
+	}
+
+	@Test(timeOut = 2000)
+	public void issue49_NPEForInvalidGPXLenient() throws IOException {
+		final String resource = "/io/jenetics/jpx/ISSUE-49.gpx";
+
+		final GPX gpx;
+		try (InputStream in = getClass().getResourceAsStream(resource)) {
+			gpx = GPX.read(in, true);
+		}
+
+		Assert.assertEquals(gpx.getWayPoints().size(), 1);
+		Assert.assertEquals(
+			gpx.getWayPoints().get(0),
+			WayPoint.builder()
+				.lat(51.39709).lon(4.501519).name("START")
+				.build()
+		);
+
+		final List<WayPoint> points = gpx.tracks()
+			.flatMap(Track::segments)
+			.flatMap(TrackSegment::points)
+			.collect(Collectors.toList());
+
+		Assert.assertEquals(points.size(), 26);
 	}
 
 	@Test(timeOut = 2000)

--- a/jpx/src/test/resources/io/jenetics/jpx/ISSUE-49.gpx
+++ b/jpx/src/test/resources/io/jenetics/jpx/ISSUE-49.gpx
@@ -1,0 +1,110 @@
+<?xml version="1.0"?>
+<gpx
+		version="1.0"
+		creator="VB Net GPS:  vermeiren-willy@pandora.be"
+		xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		xmlns="http://www.topografix.com/GPX/1/0"
+		xsi:schemaLocation="http://www.topografix.com/GPX/1/0 http://www.topografix.com/GPX/1/0/gpx.xsd">
+
+	<bounds minlat="51.396017" minlon="4.498043" maxlat="51.430402" maxlon="4.556108"/>
+	<foo>
+		<bar>1</bar>
+		<bar>2</bar>
+		<bar>3</bar>
+		<bar>4</bar>
+		<bar>
+			<zoo>d</zoo>
+			<zoo>d</zoo>
+			<zoo>d</zoo>
+		</bar>
+	</foo>
+
+	<wpt lat="51.39709" lon="4.501519">
+		<name>START</name>
+	</wpt>
+
+	<trk>
+		<name>Achterbroek naar De Maatjes   13 km TR</name>
+		<trkseg>
+			<trkpt lat="51.39709" lon="4.501519">
+				<name>1</name>
+			</trkpt>
+			<trkpt lat="51.397705" lon="4.501452">
+				<name>2</name>
+			</trkpt>
+			<trkpt lat="51.398635" lon="4.502678">
+				<name>3</name>
+			</trkpt>
+			<trkpt lat="51.404042" lon="4.498472">
+				<name>4</name>
+			</trkpt>
+			<trkpt lat="51.405072" lon="4.498043">
+				<name>5</name>
+			</trkpt>
+			<trkpt lat="51.405456" lon="4.499259">
+				<name>6</name>
+			</trkpt>
+			<trkpt lat="51.417346" lon="4.515038">
+				<name>7</name>
+			</trkpt>
+			<trkpt lat="51.41932" lon="4.513879">
+				<name>8</name>
+			</trkpt>
+			<trkpt lat="51.421552" lon="4.523535">
+				<name>9</name>
+			</trkpt>
+			<trkpt lat="51.423011" lon="4.522848">
+				<name>10</name>
+			</trkpt>
+			<trkpt lat="51.423826" lon="4.5295">
+				<name>11</name>
+			</trkpt>
+			<trkpt lat="51.427002" lon="4.528513">
+				<name>12</name>
+			</trkpt>
+			<trkpt lat="51.427131" lon="4.534478">
+				<name>13</name>
+			</trkpt>
+			<trkpt lat="51.426819" lon="4.53744">
+				<name>14</name>
+			</trkpt>
+			<trkpt lat="51.430402" lon="4.552363">
+				<name>15</name>
+			</trkpt>
+			<trkpt lat="51.426229" lon="4.555399">
+				<name>16</name>
+			</trkpt>
+			<trkpt lat="51.426015" lon="4.554734">
+				<name>17</name>
+			</trkpt>
+			<trkpt lat="51.423569" lon="4.556108">
+				<name>18</name>
+			</trkpt>
+			<trkpt lat="51.423097" lon="4.553981">
+				<name>19</name>
+			</trkpt>
+			<trkpt lat="51.41932" lon="4.546237">
+				<name>20</name>
+			</trkpt>
+			<trkpt lat="51.410952" lon="4.534092">
+				<name>21</name>
+			</trkpt>
+			<trkpt lat="51.406231" lon="4.543018">
+				<name>22</name>
+			</trkpt>
+			<trkpt lat="51.396695" lon="4.515966">
+				<name>23</name>
+			</trkpt>
+			<trkpt lat="51.396017" lon="4.515853">
+				<name>24</name>
+			</trkpt>
+			<trkpt lat="51.396858" lon="4.506495">
+				<name>25</name>
+			</trkpt>
+			<trkpt lat="51.397133" lon="4.502635">
+				<name>26</name>
+			</trkpt>
+		</trkseg>
+	</trk>
+</gpx>
+


### PR DESCRIPTION
The 'lenient' mode is also more forgiving and will ignore all unknown XML elements.