### PR TITLE
#186 - LENIENT mode allows GPX tags without creator attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -330,6 +330,12 @@ The library is licensed under the [Apache License, Version 2.0](http://www.apach
 
 ## Release notes
 
+#### Improvements
+
+* [#186](https://github.com/jenetics/jpx/issues/186): LENIENT mode allows GPX tags without creator attributes.
+
+### 3.2.1
+
 ### [3.2.0](https://github.com/jenetics/jpx/releases/tag/v3.2.0)
 
 #### Improvements

--- a/README.md
+++ b/README.md
@@ -330,11 +330,11 @@ The library is licensed under the [Apache License, Version 2.0](http://www.apach
 
 ## Release notes
 
+### 3.2.1
+
 #### Improvements
 
 * [#186](https://github.com/jenetics/jpx/issues/186): LENIENT mode allows GPX tags without creator attributes.
-
-### 3.2.1
 
 ### [3.2.0](https://github.com/jenetics/jpx/releases/tag/v3.2.0)
 

--- a/buildSrc/src/main/kotlin/Env.kt
+++ b/buildSrc/src/main/kotlin/Env.kt
@@ -52,7 +52,7 @@ object Env {
  * Information about the library and author.
  */
 object JPX {
-	const val VERSION = "3.2.0"
+	const val VERSION = "3.2.1"
 	const val ID = "jpx"
 	const val NAME = "jpx"
 	const val GROUP = "io.jenetics"

--- a/jpx/src/main/java/io/jenetics/jpx/GPX.java
+++ b/jpx/src/main/java/io/jenetics/jpx/GPX.java
@@ -302,7 +302,9 @@ public final class GPX implements Serializable {
 	 *
 	 * @param creator the name or URL of the software that created your GPX
 	 *        document. This allows others to inform the creator of a GPX
-	 *        instance document that fails to validate.
+	 *        instance document that fails to validate. If the {@code creator}
+	 *        is {@code null}, {@code "JPX - https://github.com/jenetics/jpx"}
+	 *        is used instead.
 	 * @param version the GPX version
 	 * @param metadata the metadata about the GPS file
 	 * @param wayPoints the way-points
@@ -322,7 +324,7 @@ public final class GPX implements Serializable {
 		final Document extensions
 	) {
 		_version = requireNonNull(version);
-		_creator = creator;
+		_creator = creator != null ? creator : _CREATOR;
 		_metadata = metadata;
 		_wayPoints = copyOf(wayPoints);
 		_routes = copyOf(routes);
@@ -1701,7 +1703,9 @@ public final class GPX implements Serializable {
 	 *
 	 * @param creator the name or URL of the software that created your GPX
 	 *        document. This allows others to inform the creator of a GPX
-	 *        instance document that fails to validate.
+	 *        instance document that fails to validate. If the {@code creator}
+	 *        is {@code null}, {@code "JPX - https://github.com/jenetics/jpx"}
+	 *        is used instead.
 	 * @param  version the GPX version
 	 * @param metadata the metadata about the GPS file
 	 * @param wayPoints the way-points
@@ -1737,7 +1741,9 @@ public final class GPX implements Serializable {
 	 *
 	 * @param creator the name or URL of the software that created your GPX
 	 *        document. This allows others to inform the creator of a GPX
-	 *        instance document that fails to validate.
+	 *        instance document that fails to validate. If the {@code creator}
+	 *        is {@code null}, {@code "JPX - https://github.com/jenetics/jpx"}
+	 *        is used instead.
 	 * @param metadata the metadata about the GPS file
 	 * @param wayPoints the way-points
 	 * @param routes the routes
@@ -1771,7 +1777,9 @@ public final class GPX implements Serializable {
 	 *
 	 * @param creator the name or URL of the software that created your GPX
 	 *        document. This allows others to inform the creator of a GPX
-	 *        instance document that fails to validate.
+	 *        instance document that fails to validate. If the {@code creator}
+	 *        is {@code null}, {@code "JPX - https://github.com/jenetics/jpx"}
+	 *        is used instead.
 	 * @param metadata the metadata about the GPS file
 	 * @param wayPoints the way-points
 	 * @param routes the routes
@@ -1805,7 +1813,9 @@ public final class GPX implements Serializable {
 	 *
 	 * @param creator the name or URL of the software that created your GPX
 	 *        document. This allows others to inform the creator of a GPX
-	 *        instance document that fails to validate.
+	 *        instance document that fails to validate. If the {@code creator}
+	 *        is {@code null}, {@code "JPX - https://github.com/jenetics/jpx"}
+	 *        is used instead.
 	 * @param  version the GPX version
 	 * @param metadata the metadata about the GPS file
 	 * @param wayPoints the way-points

--- a/jpx/src/main/java/io/jenetics/jpx/GPX.java
+++ b/jpx/src/main/java/io/jenetics/jpx/GPX.java
@@ -309,7 +309,7 @@ public final class GPX implements Serializable {
 	 * @param routes the routes
 	 * @param tracks the tracks
 	 * @param extensions the XML extensions document
-	 * @throws NullPointerException if the {@code creator} or {@code version} is
+	 * @throws NullPointerException if the {@code version} is
 	 *         {@code null}
 	 */
 	private GPX(
@@ -322,7 +322,7 @@ public final class GPX implements Serializable {
 		final Document extensions
 	) {
 		_version = requireNonNull(version);
-		_creator = requireNonNull(creator);
+		_creator = creator;
 		_metadata = metadata;
 		_wayPoints = copyOf(wayPoints);
 		_routes = copyOf(routes);

--- a/jpx/src/test/java/io/jenetics/jpx/GPXTest.java
+++ b/jpx/src/test/java/io/jenetics/jpx/GPXTest.java
@@ -969,7 +969,7 @@ public class GPXTest extends XMLStreamTestBase<GPX> {
 		}
 
 		assertThat(gpx_lenient.getVersion()).isEqualTo("1.1");
-		assertThat(gpx_lenient.getCreator()).isNull();
+		assertThat(gpx_lenient.getCreator()).isEqualTo("JPX - https://github.com/jenetics/jpx");
 		assertThat(gpx_lenient.getTracks()).hasSize(1);
 		assertThat(gpx_lenient.getTracks().get(0).getSegments()).hasSize(1);
 		assertThat(gpx_lenient.getTracks().get(0).getSegments().get(0)).hasSize(9);
@@ -983,8 +983,22 @@ public class GPXTest extends XMLStreamTestBase<GPX> {
 		} catch (Exception e) {
 			Assert.fail("Unexpected exception was thrown: " + e);
 		}
+	}
 
+	@Test
+	public void issue186_NullCreator() throws IOException {
+		Random random = new Random();
+		GPX createGPX = GPX.of(
+			Version.V11,
+			null,
+			random.nextBoolean() ? MetadataTest.nextMetadata(random) : null,
+			random.nextBoolean() ? WayPointTest.nextWayPoints(random) : null,
+			random.nextBoolean() ? RouteTest.nextRoutes(random) : null,
+			random.nextBoolean() ? TrackTest.nextTracks(random) : null,
+			random.nextBoolean() ? doc() : null
+		);
 
+		assertThat(createGPX.getCreator()).isEqualTo("JPX - https://github.com/jenetics/jpx");
 	}
 
 }

--- a/jpx/src/test/java/io/jenetics/jpx/GPXTest.java
+++ b/jpx/src/test/java/io/jenetics/jpx/GPXTest.java
@@ -960,4 +960,31 @@ public class GPXTest extends XMLStreamTestBase<GPX> {
 		assertThat(gpx.getTracks().get(0).getSegments().get(0)).hasSize(2);
 	}
 
+	@Test
+	public void issue186_MissingCreator() throws IOException {
+		final var resource = "/io/jenetics/jpx/ISSUE-186.gpx";
+		final GPX gpx_lenient;
+		try (InputStream in = getClass().getResourceAsStream(resource)) {
+			gpx_lenient = GPX.Reader.of(Mode.LENIENT).read(in);
+		}
+
+		assertThat(gpx_lenient.getVersion()).isEqualTo("1.1");
+		assertThat(gpx_lenient.getCreator()).isNull();
+		assertThat(gpx_lenient.getTracks()).hasSize(1);
+		assertThat(gpx_lenient.getTracks().get(0).getSegments()).hasSize(1);
+		assertThat(gpx_lenient.getTracks().get(0).getSegments().get(0)).hasSize(9);
+
+
+		try (InputStream in = getClass().getResourceAsStream("/path/to/resource")) {
+			GPX.Reader.of(Mode.STRICT).read(in);
+			Assert.fail("Expected InvalidObjectException to be thrown.");
+		} catch (NullPointerException e) {
+			// Expected to fail in STRICT mode, as Creator attribute is missing
+		} catch (Exception e) {
+			Assert.fail("Unexpected exception was thrown: " + e);
+		}
+
+
+	}
+
 }

--- a/jpx/src/test/resources/io/jenetics/jpx/ISSUE-186.gpx
+++ b/jpx/src/test/resources/io/jenetics/jpx/ISSUE-186.gpx
@@ -1,0 +1,16 @@
+<?xml version='1.0' encoding='UTF-8' standalone='yes' ?>
+<gpx version="1.1">
+	<trk>
+		<trkseg>
+			<trkpt lat="47.1849902" lon="9.3118156"><ele>1411.7906106047938</ele><time>2018-09-30T09:43:37Z</time></trkpt>
+			<trkpt lat="47.1847356" lon="9.3116516"><ele>1392.486126435269</ele><time>2018-09-30T09:44:41Z</time></trkpt>
+			<trkpt lat="47.1844677" lon="9.3115969"><ele>1395.0386210201773</ele><time>2018-09-30T09:45:09Z</time></trkpt>
+			<trkpt lat="47.1841943" lon="9.3116178"><ele>1399.1852111777555</ele><time>2018-09-30T09:45:39Z</time></trkpt>
+			<trkpt lat="47.1839262" lon="9.311698"><ele>1400.9042412783833</ele><time>2018-09-30T09:46:06Z</time></trkpt>
+			<trkpt lat="47.1836688" lon="9.3118495"><ele>1404.8712068295272</ele><time>2018-09-30T09:46:30Z</time></trkpt>
+			<trkpt lat="47.1834009" lon="9.3119155"><ele>1406.7036626781644</ele><time>2018-09-30T09:46:56Z</time></trkpt>
+			<trkpt lat="47.1831309" lon="9.3119291"><ele>1408.6363346678631</ele><time>2018-09-30T09:47:24Z</time></trkpt>
+			<trkpt lat="47.18286" lon="9.311905"><ele>1410.9618086711207</ele><time>2018-09-30T09:47:48Z</time></trkpt>
+		</trkseg>
+	</trk>
+</gpx>


### PR DESCRIPTION
Fixes #186 ; remove requireNonNull for creator attribute and add test case to differentiate LENIENT and STRICT mode.